### PR TITLE
Purplship 2020 12 compatible

### DIFF
--- a/src/eshipper/purplship/mappers/eshipper/proxy.py
+++ b/src/eshipper/purplship/mappers/eshipper/proxy.py
@@ -1,4 +1,4 @@
-from purplship.core.utils import to_xml, request as http
+from purplship.core.utils import XP, request as http
 from purplship.api.proxy import Proxy as BaseProxy
 from purplship.mappers.eshipper.settings import Settings
 from purplship.core.utils.serializable import Serializable, Deserializable
@@ -14,7 +14,7 @@ class Proxy(BaseProxy):
             headers={"Content-Type": "application/xml"},
             method="POST",
         )
-        return Deserializable(response, to_xml)
+        return Deserializable(response, XP.to_xml)
 
     def create_shipment(self, request: Serializable) -> Deserializable[str]:
         response = http(
@@ -23,7 +23,7 @@ class Proxy(BaseProxy):
             headers={"Content-Type": "application/xml"},
             method="POST",
         )
-        return Deserializable(response, to_xml)
+        return Deserializable(response, XP.to_xml)
 
     def cancel_shipment(self, request: Serializable) -> Deserializable[str]:
         response = http(
@@ -32,4 +32,4 @@ class Proxy(BaseProxy):
             headers={"Content-Type": "application/xml"},
             method="POST",
         )
-        return Deserializable(response, to_xml)
+        return Deserializable(response, XP.to_xml)

--- a/src/eshipper/purplship/providers/eshipper/error.py
+++ b/src/eshipper/purplship/providers/eshipper/error.py
@@ -1,7 +1,7 @@
 from typing import List
 from pyeshipper.error import ErrorType
 from purplship.core.models import Message
-from purplship.core.utils.xml import Element
+from purplship.core.utils import Element, XP
 from purplship.providers.eshipper.utils import Settings
 
 
@@ -11,8 +11,7 @@ def parse_error_response(response: Element, settings: Settings) -> List[Message]
 
 
 def _extract_error(error_node: Element, settings: Settings) -> Message:
-    error = ErrorType()
-    error.build(error_node)
+    error = XP.build(ErrorType, error_node)
     return Message(
         carrier_name=settings.carrier_name,
         carrier_id=settings.carrier_id,

--- a/src/eshipper/purplship/providers/eshipper/quote.py
+++ b/src/eshipper/purplship/providers/eshipper/quote.py
@@ -8,8 +8,7 @@ from pyeshipper.quote_request import (
     PackageType,
 )
 from pyeshipper.quote_reply import QuoteType, SurchargeType
-from purplship.core.utils import Element, Serializable, concat_str, decimal
-from purplship.core.utils.soap import build
+from purplship.core.utils import Element, Serializable, SF, NF, XP
 from purplship.core.models import RateRequest, RateDetails, Message, ChargeDetails
 from purplship.core.units import Packages, Options
 from purplship.providers.eshipper.utils import (
@@ -37,13 +36,13 @@ def parse_quote_reply(
 
 
 def _extract_rate(node: Element, settings: Settings) -> RateDetails:
-    quote = build(QuoteType, node)
+    quote = XP.build(QuoteType, node)
     service = next(
         (s.name for s in Service if str(quote.serviceId) == s.value), quote.serviceId
     )
     surcharges = [
         ChargeDetails(
-            name=charge.name, amount=decimal(charge.amount), currency=quote.currency
+            name=charge.name, amount=NF.decimal(charge.amount), currency=quote.currency
         )
         for charge in cast(List[SurchargeType], quote.Surcharge)
     ]
@@ -51,7 +50,7 @@ def _extract_rate(node: Element, settings: Settings) -> RateDetails:
     fuel_surcharge = (
         ChargeDetails(
             name="Fuel surcharge",
-            amount=decimal(quote.fuelSurcharge),
+            amount=NF.decimal(quote.fuelSurcharge),
             currency=quote.currency,
         )
         if quote.fuelSurcharge is not None
@@ -63,8 +62,8 @@ def _extract_rate(node: Element, settings: Settings) -> RateDetails:
         carrier_id=settings.carrier_id,
         currency=quote.currency,
         service=service,
-        base_charge=decimal(quote.baseCharge),
-        total_charge=decimal(quote.totalCharge),
+        base_charge=NF.decimal(quote.baseCharge),
+        total_charge=NF.decimal(quote.totalCharge),
         transit_days=quote.transitDays,
         extra_charges=[fuel_surcharge] + surcharges
     )
@@ -143,8 +142,8 @@ def quote_request(payload: RateRequest, settings: Settings) -> Serializable[EShi
                 phone=payload.shipper.phone_number,
                 tailgateRequired=None,
                 residential=payload.shipper.residential,
-                address1=concat_str(payload.shipper.address_line1, join=True),
-                address2=concat_str(payload.shipper.address_line2, join=True),
+                address1=SF.concat_str(payload.shipper.address_line1, join=True),
+                address2=SF.concat_str(payload.shipper.address_line2, join=True),
                 city=payload.shipper.city,
                 state=payload.shipper.state_code,
                 zip=payload.shipper.postal_code,
@@ -160,8 +159,8 @@ def quote_request(payload: RateRequest, settings: Settings) -> Serializable[EShi
                 phone=payload.recipient.phone_number,
                 tailgateRequired=None,
                 residential=payload.recipient.residential,
-                address1=concat_str(payload.recipient.address_line1, join=True),
-                address2=concat_str(payload.recipient.address_line2, join=True),
+                address1=SF.concat_str(payload.recipient.address_line1, join=True),
+                address2=SF.concat_str(payload.recipient.address_line2, join=True),
                 city=payload.recipient.city,
                 state=payload.recipient.state_code,
                 zip=payload.recipient.postal_code,

--- a/src/eshipper/purplship/providers/eshipper/shipping.py
+++ b/src/eshipper/purplship/providers/eshipper/shipping.py
@@ -21,8 +21,7 @@ from pyeshipper.shipping_reply import (
     PackageType as ReplyPackageType,
     SurchargeType,
 )
-from purplship.core.utils import Element, Serializable, concat_str, decimal
-from purplship.core.utils.soap import build
+from purplship.core.utils import Element, Serializable, SF, NF, XP
 from purplship.core.models import (
     ShipmentRequest,
     ShipmentDetails,
@@ -62,7 +61,7 @@ def parse_shipping_reply(
 
 
 def _extract_shipment(node: Element, settings: Settings) -> ShipmentDetails:
-    shipping = build(ShippingReplyType, node)
+    shipping = XP.build(ShippingReplyType, node)
     quote: QuoteType = shipping.Quote
     package: ReplyPackageType = next(iter(shipping.Package), None)
     tracking_number = package.trackingNumber if package is not None else None
@@ -71,7 +70,7 @@ def _extract_shipment(node: Element, settings: Settings) -> ShipmentDetails:
     )
     surcharges = [
         ChargeDetails(
-            name=charge.name, amount=decimal(charge.amount), currency=quote.currency
+            name=charge.name, amount=NF.decimal(charge.amount), currency=quote.currency
         )
         for charge in cast(List[SurchargeType], quote.Surcharge)
     ]
@@ -79,7 +78,7 @@ def _extract_shipment(node: Element, settings: Settings) -> ShipmentDetails:
     fuel_surcharge = (
         ChargeDetails(
             name="Fuel surcharge",
-            amount=decimal(quote.fuelSurcharge),
+            amount=NF.decimal(quote.fuelSurcharge),
             currency=quote.currency,
         )
         if quote.fuelSurcharge is not None
@@ -97,8 +96,8 @@ def _extract_shipment(node: Element, settings: Settings) -> ShipmentDetails:
             carrier_id=settings.carrier_id,
             service=service,
             currency=quote.currency,
-            base_charge=decimal(quote.baseCharge),
-            total_charge=decimal(quote.totalCharge),
+            base_charge=NF.decimal(quote.baseCharge),
+            total_charge=NF.decimal(quote.totalCharge),
             transit_days=quote.transitDays,
             extra_charges=[fuel_surcharge] + surcharges,
         )
@@ -191,8 +190,8 @@ def shipping_request(
                 phone=payload.shipper.phone_number,
                 tailgateRequired=None,
                 residential=payload.shipper.residential,
-                address1=concat_str(payload.shipper.address_line1, join=True),
-                address2=concat_str(payload.shipper.address_line2, join=True),
+                address1=SF.concat_str(payload.shipper.address_line1, join=True),
+                address2=SF.concat_str(payload.shipper.address_line2, join=True),
                 city=payload.shipper.city,
                 state=payload.shipper.state_code,
                 zip=payload.shipper.postal_code,
@@ -208,8 +207,8 @@ def shipping_request(
                 phone=payload.recipient.phone_number,
                 tailgateRequired=None,
                 residential=payload.recipient.residential,
-                address1=concat_str(payload.recipient.address_line1, join=True),
-                address2=concat_str(payload.recipient.address_line2, join=True),
+                address1=SF.concat_str(payload.recipient.address_line1, join=True),
+                address2=SF.concat_str(payload.recipient.address_line2, join=True),
                 city=payload.recipient.city,
                 state=payload.recipient.state_code,
                 zip=payload.recipient.postal_code,
@@ -220,7 +219,7 @@ def shipping_request(
                 CODReturnAddress=CODReturnAddressType(
                     codCompany=payload.recipient.company_name,
                     codName=payload.recipient.person_name,
-                    codAddress1=concat_str(payload.recipient.address_line1, join=True),
+                    codAddress1=SF.concat_str(payload.recipient.address_line1, join=True),
                     codCity=payload.recipient.city,
                     codStateCode=payload.recipient.state_code,
                     codZip=payload.recipient.postal_code,
@@ -257,7 +256,7 @@ def shipping_request(
                 BillTo=BillToType(
                     company=payer.company_name,
                     name=payer.person_name,
-                    address1=concat_str(payer.address_line1, join=True),
+                    address1=SF.concat_str(payer.address_line1, join=True),
                     city=payer.city,
                     state=payer.state_code,
                     zip=payer.postal_code,

--- a/src/eshipper/purplship/providers/eshipper/utils.py
+++ b/src/eshipper/purplship/providers/eshipper/utils.py
@@ -1,7 +1,7 @@
 import math
 from typing import Optional
 from purplship.core import Settings as BaseSettings
-from purplship.core.utils import export
+from purplship.core.utils import XP
 
 
 class Settings(BaseSettings):
@@ -24,7 +24,7 @@ class Settings(BaseSettings):
 
 
 def standard_request_serializer(request) -> str:
-    return export(request, namespacedef_='xmlns="http://www.eshipper.net/XMLSchema"')
+    return XP.export(request, namespacedef_='xmlns="http://www.eshipper.net/XMLSchema"')
 
 
 def ceil(value: Optional[float]) -> Optional[int]:

--- a/src/eshipper/requirements.dev.txt
+++ b/src/eshipper/requirements.dev.txt
@@ -1,7 +1,7 @@
 -f https://git.io/purplship
 
--e git+https://github.com/PurplShip/purplship.git@purplship-2020.12#egg=purplship
-# -e git+https://github.com/PurplShip/purplship-server.git@purplship-server-2020.12#egg=purplship_server.core&subdirectory=src/apps/core
+# -e git+https://github.com/PurplShip/purplship.git@purplship-2020.12#egg=purplship
+ -e git+https://github.com/PurplShip/purplship-server.git@purplship-2020.12#egg=purplship_server.core&subdirectory=src/apps/core
 # -e git+https://github.com/PurplShip/purplship-server.git@purplship-server-2020.12#egg=purplship_server&subdirectory=src/purpleserver
 
 -e .[dev]

--- a/src/eshipper/requirements.dev.txt
+++ b/src/eshipper/requirements.dev.txt
@@ -1,6 +1,7 @@
 -f https://git.io/purplship
 
--e git+https://github.com/PurplShip/purplship-server.git@purplship-server-2020.10.0#egg=purplship_server.core&subdirectory=src/apps/core
--e git+https://github.com/PurplShip/purplship-server.git@purplship-server-2020.10.0#egg=purplship_server&subdirectory=src/purpleserver
+-e git+https://github.com/PurplShip/purplship.git@purplship-2020.12#egg=purplship
+# -e git+https://github.com/PurplShip/purplship-server.git@purplship-server-2020.12#egg=purplship_server.core&subdirectory=src/apps/core
+# -e git+https://github.com/PurplShip/purplship-server.git@purplship-server-2020.12#egg=purplship_server&subdirectory=src/purpleserver
 
 -e .[dev]

--- a/src/eshipper/script.sh
+++ b/src/eshipper/script.sh
@@ -38,14 +38,17 @@ alias env:reset=init
 
 # shellcheck disable=SC2120
 test() {
-    coverage run -m unittest discover -v "${ROOT:?}/tests"
+  cd "${ROOT:?}"
+  r=$(coverage run -m unittest discover -f -v "${ROOT:?}/tests"; echo $?)
+  cd -
+  return "$r"
 }
 
 typecheck() {
   cd "${ROOT:?}"
-  for submodule in $(find "purplship" -type f -name "__init__.py" -exec dirname {} \;); do
-    mypy -p "${submodule//'\/'/.}" || break
-  done || break
+  for submodule in $(find "purplship" -type f -name "__init__.py" -exec dirname '{}' \;); do
+    mypy "$submodule" || return $?
+  done
   cd -
 }
 

--- a/src/eshipper/setup.py
+++ b/src/eshipper/setup.py
@@ -25,7 +25,7 @@ dev_requirements = [
 
 setup(
     name="eshipper.extension",
-    version="2020.10.0",
+    version="2020.12",
     description="eShipper purplship extension",
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/src/eshipper/setup.py
+++ b/src/eshipper/setup.py
@@ -34,8 +34,8 @@ setup(
     packages=find_namespace_packages(exclude=["tests*"]),
     install_requires=[
         "six",
-        "purplship>=2020.10.0",
-        "purplship-server.core>=2020.10.0",
+        "purplship>=2020.12",
+        "purplship-server.core>=2020.12",
     ],
     extras_require={"dev": dev_requirements},
     dependency_links=[],

--- a/src/eshipper/tests/eshipper/rate.py
+++ b/src/eshipper/tests/eshipper/rate.py
@@ -1,6 +1,6 @@
 import unittest
 from unittest.mock import patch
-from purplship.core.utils.helpers import to_dict
+from purplship.core.utils import DP
 from purplship.core.models import RateRequest
 from purplship.core.errors import FieldError
 from purplship import Rating
@@ -35,7 +35,7 @@ class TestEShipperRating(unittest.TestCase):
             mock.return_value = RateResponseXml
             parsed_response = Rating.fetch(self.RateRequest).from_(gateway).parse()
 
-            self.assertEqual(to_dict(parsed_response), to_dict(ParsedQuoteResponse))
+            self.assertEqual(DP.to_dict(parsed_response), DP.to_dict(ParsedQuoteResponse))
 
 
 if __name__ == "__main__":

--- a/src/eshipper/tests/eshipper/shipment.py
+++ b/src/eshipper/tests/eshipper/shipment.py
@@ -1,6 +1,6 @@
 import unittest
 from unittest.mock import patch
-from purplship.core.utils.helpers import to_dict
+from purplship.core.utils import DP
 from purplship.core.models import ShipmentRequest, ShipmentCancelRequest
 from purplship import Shipment
 from tests.eshipper.fixture import gateway
@@ -45,7 +45,7 @@ class TestEShipperShipment(unittest.TestCase):
                 Shipment.create(self.ShipmentRequest).with_(gateway).parse()
             )
 
-            self.assertEqual(to_dict(parsed_response), to_dict(ParsedShipmentResponse))
+            self.assertEqual(DP.to_dict(parsed_response), DP.to_dict(ParsedShipmentResponse))
 
     def test_parse_cancel_shipment_response(self):
         with patch("purplship.mappers.eshipper.proxy.http") as mock:
@@ -54,7 +54,7 @@ class TestEShipperShipment(unittest.TestCase):
                 Shipment.cancel(self.ShipmentCancelRequest).from_(gateway).parse()
             )
 
-            self.assertEqual(to_dict(parsed_response), to_dict(ParsedCancelShipmentResponse))
+            self.assertEqual(DP.to_dict(parsed_response), DP.to_dict(ParsedCancelShipmentResponse))
 
 
 if __name__ == "__main__":

--- a/src/freightcom/purplship/mappers/freightcom/proxy.py
+++ b/src/freightcom/purplship/mappers/freightcom/proxy.py
@@ -1,4 +1,4 @@
-from purplship.core.utils import to_xml, request as http
+from purplship.core.utils import request as http, XP
 from purplship.api.proxy import Proxy as BaseProxy
 from purplship.mappers.freightcom.settings import Settings
 from purplship.core.utils.serializable import Serializable, Deserializable
@@ -14,7 +14,7 @@ class Proxy(BaseProxy):
             headers={"Content-Type": "application/xml"},
             method="POST",
         )
-        return Deserializable(response, to_xml)
+        return Deserializable(response, XP.to_xml)
 
     def create_shipment(self, request: Serializable) -> Deserializable[str]:
         response = http(
@@ -23,7 +23,7 @@ class Proxy(BaseProxy):
             headers={"Content-Type": "application/xml"},
             method="POST",
         )
-        return Deserializable(response, to_xml)
+        return Deserializable(response, XP.to_xml)
 
     def cancel_shipment(self, request: Serializable) -> Deserializable[str]:
         response = http(
@@ -32,4 +32,4 @@ class Proxy(BaseProxy):
             headers={"Content-Type": "application/xml"},
             method="POST",
         )
-        return Deserializable(response, to_xml)
+        return Deserializable(response, XP.to_xml)

--- a/src/freightcom/purplship/providers/freightcom/error.py
+++ b/src/freightcom/purplship/providers/freightcom/error.py
@@ -2,7 +2,7 @@ from typing import List
 from pyfreightcom.error import ErrorType
 from pyfreightcom.quote_reply import CarrierErrorMessageType
 from purplship.core.models import Message
-from purplship.core.utils.xml import Element
+from purplship.core.utils import Element, XP
 from purplship.providers.freightcom.utils import Settings
 
 
@@ -17,8 +17,7 @@ def parse_error_response(response: Element, settings: Settings) -> List[Message]
 
 
 def _extract_carrier_error(error_node: Element, settings: Settings) -> Message:
-    error = CarrierErrorMessageType()
-    error.build(error_node)
+    error = XP.build(CarrierErrorMessageType, error_node)
     return Message(
         code="",
         carrier_name=settings.carrier_name,
@@ -28,8 +27,7 @@ def _extract_carrier_error(error_node: Element, settings: Settings) -> Message:
 
 
 def _extract_error(error_node: Element, settings: Settings) -> Message:
-    error = ErrorType()
-    error.build(error_node)
+    error = XP.build(ErrorType, error_node)
     return Message(
         code="",
         carrier_name=settings.carrier_name,

--- a/src/freightcom/purplship/providers/freightcom/shipping.py
+++ b/src/freightcom/purplship/providers/freightcom/shipping.py
@@ -21,7 +21,7 @@ from pyfreightcom.shipping_reply import (
     PackageType as ReplyPackageType,
     SurchargeType,
 )
-from purplship.core.utils import Element, Serializable, concat_str, decimal
+from purplship.core.utils import Element, Serializable, XP, SF, NF
 from purplship.core.models import (
     ShipmentRequest,
     ShipmentDetails,
@@ -61,8 +61,7 @@ def parse_shipping_reply(
 
 
 def _extract_shipment(node: Element, settings: Settings) -> ShipmentDetails:
-    shipping = ShippingReplyType()
-    shipping.build(node)
+    shipping = XP.build(ShippingReplyType, node)
     quote: QuoteType = shipping.Quote
     package: ReplyPackageType = next(iter(shipping.Package), None)
     tracking_number = package.trackingNumber if package is not None else None
@@ -71,7 +70,7 @@ def _extract_shipment(node: Element, settings: Settings) -> ShipmentDetails:
     )
     surcharges = [
         ChargeDetails(
-            name=charge.name, amount=decimal(charge.amount), currency=quote.currency
+            name=charge.name, amount=NF.decimal(charge.amount), currency=quote.currency
         )
         for charge in cast(List[SurchargeType], quote.Surcharge)
     ]
@@ -79,7 +78,7 @@ def _extract_shipment(node: Element, settings: Settings) -> ShipmentDetails:
     fuel_surcharge = (
         ChargeDetails(
             name="Fuel surcharge",
-            amount=decimal(quote.fuelSurcharge),
+            amount=NF.decimal(quote.fuelSurcharge),
             currency=quote.currency,
         )
         if quote.fuelSurcharge is not None
@@ -97,8 +96,8 @@ def _extract_shipment(node: Element, settings: Settings) -> ShipmentDetails:
             carrier_id=settings.carrier_id,
             service=service,
             currency=quote.currency,
-            base_charge=decimal(quote.baseCharge),
-            total_charge=decimal(quote.totalCharge),
+            base_charge=NF.decimal(quote.baseCharge),
+            total_charge=NF.decimal(quote.totalCharge),
             transit_days=quote.transitDays,
             extra_charges=[fuel_surcharge] + surcharges,
         )
@@ -197,8 +196,8 @@ def shipping_request(
                 phone=payload.shipper.phone_number,
                 tailgateRequired=None,
                 residential=payload.shipper.residential,
-                address1=concat_str(payload.shipper.address_line1, join=True),
-                address2=concat_str(payload.shipper.address_line2, join=True),
+                address1=SF.concat_str(payload.shipper.address_line1, join=True),
+                address2=SF.concat_str(payload.shipper.address_line2, join=True),
                 city=payload.shipper.city,
                 state=payload.shipper.state_code,
                 zip=payload.shipper.postal_code,
@@ -214,8 +213,8 @@ def shipping_request(
                 phone=payload.recipient.phone_number,
                 tailgateRequired=None,
                 residential=payload.recipient.residential,
-                address1=concat_str(payload.recipient.address_line1, join=True),
-                address2=concat_str(payload.recipient.address_line2, join=True),
+                address1=SF.concat_str(payload.recipient.address_line1, join=True),
+                address2=SF.concat_str(payload.recipient.address_line2, join=True),
                 city=payload.recipient.city,
                 state=payload.recipient.state_code,
                 zip=payload.recipient.postal_code,
@@ -226,7 +225,7 @@ def shipping_request(
                 CODReturnAddress=CODReturnAddressType(
                     codCompany=payload.recipient.company_name,
                     codName=payload.recipient.person_name,
-                    codAddress1=concat_str(payload.recipient.address_line1, join=True),
+                    codAddress1=SF.concat_str(payload.recipient.address_line1, join=True),
                     codCity=payload.recipient.city,
                     codStateCode=payload.recipient.state_code,
                     codZip=payload.recipient.postal_code,
@@ -263,7 +262,7 @@ def shipping_request(
                 BillTo=BillToType(
                     company=payer.company_name,
                     name=payer.person_name,
-                    address1=concat_str(payer.address_line1, join=True),
+                    address1=SF.concat_str(payer.address_line1, join=True),
                     city=payer.city,
                     state=payer.state_code,
                     zip=payer.postal_code,

--- a/src/freightcom/purplship/providers/freightcom/utils.py
+++ b/src/freightcom/purplship/providers/freightcom/utils.py
@@ -1,7 +1,7 @@
 import math
 from typing import Optional
 from purplship.core import Settings as BaseSettings
-from purplship.core.utils import export
+from purplship.core.utils import XP
 
 
 class Settings(BaseSettings):
@@ -24,7 +24,7 @@ class Settings(BaseSettings):
 
 
 def standard_request_serializer(element) -> str:
-    return export(element, namespacedef_='xmlns="http://www.freightcom.net/XMLSchema"')
+    return XP.export(element, namespacedef_='xmlns="http://www.freightcom.net/XMLSchema"')
 
 
 def ceil(value: Optional[float]) -> Optional[int]:

--- a/src/freightcom/requirements.dev.txt
+++ b/src/freightcom/requirements.dev.txt
@@ -1,6 +1,7 @@
 -f https://git.io/purplship
 
--e git+https://github.com/PurplShip/purplship-server.git@purplship-server-2020.10.0#egg=purplship_server.core&subdirectory=src/apps/core
--e git+https://github.com/PurplShip/purplship-server.git@purplship-server-2020.10.0#egg=purplship_server&subdirectory=src/purpleserver
+-e git+https://github.com/PurplShip/purplship.git@purplship-2020.12#egg=purplship
+# -e git+https://github.com/PurplShip/purplship-server.git@purplship-server-2020.12#egg=purplship_server.core&subdirectory=src/apps/core
+# -e git+https://github.com/PurplShip/purplship-server.git@purplship-server-2020.12#egg=purplship_server&subdirectory=src/purpleserver
 
 -e .[dev]

--- a/src/freightcom/requirements.dev.txt
+++ b/src/freightcom/requirements.dev.txt
@@ -1,7 +1,7 @@
 -f https://git.io/purplship
 
--e git+https://github.com/PurplShip/purplship.git@purplship-2020.12#egg=purplship
-# -e git+https://github.com/PurplShip/purplship-server.git@purplship-server-2020.12#egg=purplship_server.core&subdirectory=src/apps/core
-# -e git+https://github.com/PurplShip/purplship-server.git@purplship-server-2020.12#egg=purplship_server&subdirectory=src/purpleserver
+# -e git+https://github.com/PurplShip/purplship.git@purplship-2020.12#egg=purplship
+-e git+https://github.com/PurplShip/purplship-server.git@purplship-2020.12#egg=purplship_server.core&subdirectory=src/apps/core
+# -e git+https://github.com/PurplShip/purplship-server.git@purplship-2020.12#egg=purplship_server&subdirectory=src/purpleserver
 
 -e .[dev]

--- a/src/freightcom/script.sh
+++ b/src/freightcom/script.sh
@@ -38,14 +38,17 @@ alias env:reset=init
 
 # shellcheck disable=SC2120
 test() {
-    coverage run -m unittest discover -v "${ROOT:?}/tests"
+  cd "${ROOT:?}"
+  r=$(coverage run -m unittest discover -f -v "${ROOT:?}/tests"; echo $?)
+  cd -
+  return "$r"
 }
 
 typecheck() {
   cd "${ROOT:?}"
-  for submodule in $(find "purplship" -type f -name "__init__.py" -exec dirname {} \;); do
-    mypy -p "${submodule//'\/'/.}" || break
-  done || break
+  for submodule in $(find "purplship" -type f -name "__init__.py" -exec dirname '{}' \;); do
+    mypy "$submodule" || return $?
+  done
   cd -
 }
 

--- a/src/freightcom/setup.py
+++ b/src/freightcom/setup.py
@@ -34,8 +34,8 @@ setup(
     packages=find_namespace_packages(exclude=["tests*"]),
     install_requires=[
         "six",
-        "purplship>=2020.10.0",
-        "purplship-server.core>=2020.10.0",
+        "purplship>=2020.12",
+        "purplship-server.core>=2020.12",
     ],
     extras_require={"dev": dev_requirements},
     dependency_links=[],

--- a/src/freightcom/setup.py
+++ b/src/freightcom/setup.py
@@ -25,7 +25,7 @@ dev_requirements = [
 
 setup(
     name="freightcom.extension",
-    version="2020.10.0",
+    version="2020.12",
     description="Freightcom purplship extension",
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/src/freightcom/tests/freightcom/rate.py
+++ b/src/freightcom/tests/freightcom/rate.py
@@ -1,6 +1,6 @@
 import unittest
 from unittest.mock import patch
-from purplship.core.utils.helpers import to_dict
+from purplship.core.utils import DP
 from purplship.core.models import RateRequest
 from purplship.core.errors import FieldError
 from purplship import Rating
@@ -35,14 +35,14 @@ class TestFreightcomRating(unittest.TestCase):
             mock.return_value = RateResponseXml
             parsed_response = Rating.fetch(self.RateRequest).from_(gateway).parse()
 
-            self.assertEqual(to_dict(parsed_response), to_dict(ParsedQuoteResponse))
+            self.assertEqual(DP.to_dict(parsed_response), DP.to_dict(ParsedQuoteResponse))
 
     def test_parse_rate_response_error(self):
         with patch("purplship.mappers.freightcom.proxy.http") as mock:
             mock.return_value = RateErrorResponseXML
             parsed_response = Rating.fetch(self.RateRequest).from_(gateway).parse()
 
-            self.assertEqual(to_dict(parsed_response), to_dict(ParsedRateError))
+            self.assertEqual(DP.to_dict(parsed_response), DP.to_dict(ParsedRateError))
 
 
 if __name__ == "__main__":

--- a/src/freightcom/tests/freightcom/shipment.py
+++ b/src/freightcom/tests/freightcom/shipment.py
@@ -1,6 +1,6 @@
 import unittest
 from unittest.mock import patch
-from purplship.core.utils.helpers import to_dict
+from purplship.core.utils import DP
 from purplship.core.models import ShipmentRequest, ShipmentCancelRequest
 from purplship import Shipment
 from tests.freightcom.fixture import gateway
@@ -45,7 +45,7 @@ class TestFreightcomShipment(unittest.TestCase):
                 Shipment.create(self.ShipmentRequest).with_(gateway).parse()
             )
 
-            self.assertEqual(to_dict(parsed_response), to_dict(ParsedShipmentResponse))
+            self.assertEqual(DP.to_dict(parsed_response), DP.to_dict(ParsedShipmentResponse))
 
     def test_parse_cancel_shipment_response(self):
         with patch("purplship.mappers.freightcom.proxy.http") as mock:
@@ -54,7 +54,7 @@ class TestFreightcomShipment(unittest.TestCase):
                 Shipment.cancel(self.ShipmentCancelRequest).from_(gateway).parse()
             )
 
-            self.assertEqual(to_dict(parsed_response), to_dict(ParsedCancelShipmentResponse))
+            self.assertEqual(DP.to_dict(parsed_response), DP.to_dict(ParsedCancelShipmentResponse))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Compatible with Purplship 2020.12

- Update `purplship.core.utils` usages for `eshipper` and `freightcom` integrations